### PR TITLE
Adds support for WebP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 Take a gif/jpeg/png/webp, make a meme. Written in Go (Golang)
 
+Forked from: [peterebden/gomeme](https://github.com/peterebden/gomeme) and 
+[jpoz/gomeme](https://github.com/jpoz/gomeme)
+
 ## Installation
 
 ```
-go get -u github.com/koalalorenzo/gomeme/cmd/gomeme
+go get -u gitlab.com/koalalorenzo/gomeme/cmd/gomeme
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # gomeme
 
-Take a gif/jpeg/png, make a meme. Written in Go (Golang)
+Take a gif/jpeg/png/webp, make a meme. Written in Go (Golang)
 
 ## Installation
 
 ```
-go get -u github.com/jpoz/gomeme/cmd/gomeme
+go get -u github.com/koalalorenzo/gomeme/cmd/gomeme
 ```
 
 ## Usage

--- a/cmd/gomeme/gomeme.go
+++ b/cmd/gomeme/gomeme.go
@@ -11,7 +11,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/peterebden/gomeme"
+	"github.com/koalalorenzo/gomeme"
+	"golang.org/x/image/webp"
 )
 
 // Version of gomeme
@@ -79,6 +80,12 @@ func main() {
 			fail("Failed to decode png", err)
 		}
 		meme.Memeable = gomeme.PNG{p}
+	case "image/webp":
+		i, err := webp.Decode(buff)
+		if err != nil {
+			fail("Failed to decode webp", err)
+		}
+		meme.Memeable = gomeme.WebP{i}
 	default:
 		fail(fmt.Sprintf("No idea what todo with a %s", contentType), nil)
 	}

--- a/cmd/gomeme/gomeme.go
+++ b/cmd/gomeme/gomeme.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/koalalorenzo/gomeme"
+	"gitlab.com/koalalorenzo/gomeme"
 	"golang.org/x/image/webp"
 )
 

--- a/cmd/gomeme/gomeme.go
+++ b/cmd/gomeme/gomeme.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/jpoz/gomeme"
+	"github.com/peterebden/gomeme"
 )
 
 // Version of gomeme

--- a/config.go
+++ b/config.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/image/math/fixed"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/jpoz/dilation"
 )
 
 // DefaultFontSize is the default size of the font
@@ -128,11 +127,6 @@ func (c *Config) TextImage(bounds image.Rectangle) (*image.RGBA, error) {
 		d.DrawString(c.BottomText)
 	}
 
-	// Dialate aka give text a stroke
-	dilation.Dialate(textImage, dilation.DialateConfig{
-		Stroke:      c.FontStrokeSize,
-		StrokeColor: c.FontStrokeColor,
-	})
-
-	return textImage, nil
+	// Give text an outline
+	return outline(textImage, c.FontStrokeSize, c.FontStrokeColor), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module gitlab.com/koalalorenzo/gomeme
 
-go 1.17
+go 1.19
 
 require (
-	github.com/chai2010/webp v1.1.0
+	github.com/chai2010/webp v1.1.1
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
+	golang.org/x/image v0.0.0-20220722155232-062f8c9fd539
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/koalalorenzo/gomeme
+module gitlab.com/koalalorenzo/gomeme
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/peterebden/gomeme
+module github.com/koalalorenzo/gomeme
 
-go 1.12
+go 1.17
 
 require (
+	github.com/chai2010/webp v1.1.0
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec
+	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/peterebden/gomeme
+
+go 1.12
+
+require (
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+	golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec h1:arXJwtMuk5vqI1NHX0UTnNw977rYk5Sl4jQqHj+hun4=
+golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
+github.com/chai2010/webp v1.1.0 h1:4Ei0/BRroMF9FaXDG2e4OxwFcuW2vcXd+A6tyqTJUQQ=
+github.com/chai2010/webp v1.1.0/go.mod h1:LP12PG5IFmLGHUU26tBiCBKnghxx3toZFwDjOYvd3Ow=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
-golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec h1:arXJwtMuk5vqI1NHX0UTnNw977rYk5Sl4jQqHj+hun4=
-golang.org/x/image v0.0.0-20190507092727-e4e5bf290fec/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/chai2010/webp v1.1.0 h1:4Ei0/BRroMF9FaXDG2e4OxwFcuW2vcXd+A6tyqTJUQQ=
-github.com/chai2010/webp v1.1.0/go.mod h1:LP12PG5IFmLGHUU26tBiCBKnghxx3toZFwDjOYvd3Ow=
+github.com/chai2010/webp v1.1.1 h1:jTRmEccAJ4MGrhFOrPMpNGIJ/eybIgwKpcACsrTEapk=
+github.com/chai2010/webp v1.1.1/go.mod h1:0XVwvZWdjjdxpUEIf7b9g9VkHFnInUSYujwqTLEuldU=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
-golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
-golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/image v0.0.0-20220722155232-062f8c9fd539 h1:/eM0PCrQI2xd471rI+snWuu251/+/jpBpZqir2mPdnU=
+golang.org/x/image v0.0.0-20220722155232-062f8c9fd539/go.mod h1:doUCurBvlfPMKfmIpRIywoHmhN3VyhnoFDbvIEWF4hY=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/outline.go
+++ b/outline.go
@@ -1,0 +1,49 @@
+package gomeme
+
+import (
+	"image"
+	"image/color"
+	"image/draw"
+	"math"
+)
+
+// Outline puts an outline of given width around all non-transparent pixels in the image.
+// This is not a particularly clever or efficient implementation.
+func outline(img *image.RGBA, size int, color color.Color) *image.RGBA {
+	width := img.Bounds().Size().X
+	height := img.Bounds().Size().Y
+	circle := drawCircle(size, color)
+	nimg := image.NewRGBA(image.Rect(0, 0, width, height))
+	zero := image.Point{}
+	for x := 0; x < width; x++ {
+		for y := 0; y < height; y++ {
+			if img.RGBAAt(x, y).A > 0 {
+				rect := image.Rectangle{
+					Min: image.Point{X: x - size, Y: y - size},
+					Max: image.Point{X: x + size, Y: y + size},
+				}
+				draw.Over.Draw(nimg, rect, circle, zero)
+			}
+		}
+	}
+	draw.Over.Draw(nimg, img.Bounds(), img, zero)
+	return nimg
+}
+
+// drawCircle returns an image containing a circle of the given size.
+func drawCircle(size int, clr color.Color) *image.RGBA {
+	sz := size*2 + 1
+	img := image.NewRGBA(image.Rect(0, 0, sz, sz))
+	r, g, b, _ := clr.RGBA()
+	for x := -size + 1; x < size; x++ {
+		for y := -size + 1; y < size; y++ {
+			xr := math.Abs(float64(x))
+			yr := math.Abs(float64(y))
+			dist := math.Sqrt(xr*xr + yr*yr)
+			alpha := math.Min(math.Max(float64(size)-dist, 0.0), 1.0)
+			c := color.RGBA{R: uint8(r), G: uint8(g), B: uint8(b), A: uint8(alpha * 255)}
+			img.Set(x+size, y+size, c)
+		}
+	}
+	return img
+}

--- a/webp.go
+++ b/webp.go
@@ -1,0 +1,29 @@
+package gomeme
+
+import (
+	"image"
+	"image/draw"
+	"io"
+
+	"github.com/chai2010/webp"
+)
+
+// WebP comprises of all things needed to create a new
+// meme from a Image
+type WebP struct {
+	Image image.Image
+}
+
+// Bounds return the bounds of the first frame
+func (i WebP) Bounds() image.Rectangle {
+	return i.Image.Bounds()
+}
+
+// Write Image to writer
+func (i WebP) Write(textImage *image.RGBA, w io.Writer) error {
+	output := image.NewRGBA(i.Bounds())
+	draw.Draw(output, i.Bounds(), i.Image, image.ZP, draw.Src)
+	draw.DrawMask(output, i.Bounds(), textImage, image.ZP, textImage, image.ZP, draw.Over)
+
+	return webp.Encode(w, output, &webp.Options{Lossless: true})
+}


### PR DESCRIPTION
Hello,
I am using your module in my Twitch Meme Bot generator (I wrote a blog post about it [here](https://blog.setale.me/2021/12/18/A-Twitch-bot-to-create-memes-and-show-them-live/)). As I needed to add smaller image formats I added support to WebP. I added also some changes from @peterebden

Sadly this fork adds libraries that forces building only using GCC as I was not able to find a native go WebP decoder and encoder. This support only WebP and not Animated WebP. It would be nice to contribute back on that too if I have time.

Feel free to suggest changes, update it or discard it entirely if you want! Thank you so much @jpoz for this go module, I had a lot of fun generating images! ❤️